### PR TITLE
add page-level styling for components

### DIFF
--- a/_includes/button.html
+++ b/_includes/button.html
@@ -1,4 +1,4 @@
 <!--
     Documentation: https://github.com/pglevy/rwp-toolkit/wiki/Components#button
 -->
-<a href="{{ include.link }}" class="usa-button {{ include.style }}"{% if include.new-tab %} target="_blank"{% endif %}>{{ include.label }}</a>
+<a href="{{ include.link }}" class="usa-button {{ page.button-style }} {{ include.style }}"{% if include.new-tab %} target="_blank"{% endif %}>{{ include.label }}</a>

--- a/_includes/text-input.html
+++ b/_includes/text-input.html
@@ -3,7 +3,7 @@
 -->
 <label class="usa-label {{ include.label-style }}" for="{{ include.id }}">{{ include.label }}</label>
 <input
-  class="usa-input {{ include.input-style }}"
+  class="usa-input {{ page.text-input-style }} {{ include.style }}"
   id="{{ include.id }}"
   name="{{ include.id }}"
   type="{{ include.type }}"

--- a/templates/create-account.md
+++ b/templates/create-account.md
@@ -2,6 +2,8 @@
 layout: default
 header: false
 prose: true
+button-style: usa-button--big bg-primary-vivid hover:bg-primary-darker
+text-input-style: radius-lg padding-3 border-2px border-base
 ---
 
 # Create your account
@@ -17,4 +19,4 @@ prose: true
 After creating your account, you'll receive a message with a link to set up your username and password.
 
 <!-- Include a button component as a call-to-action for completing the form. -->
-{% include button.html label="Create" link="../index.html" style="usa-button--big" new-tab=false %}
+{% include button.html label="Create" link="../index.html" %}


### PR DESCRIPTION
This approach provides two "hooks" for styling components:
1. As part of the include, where it was before.
2. As part of the page front matter.

This is helpful for a couple reasons:
1. Adding a bunch of styling classes to the include itself could quickly add a lot of text to the page, making it harder to scan and work with the content.
2. If you were using multiple instances of a component, you had to repeat the styling, resulting in even more non-content text on the page and the strong possibility for inconsistency.

By setting up the component this way, you have the option to add styling using the page front matter that will affect all instances or using the include to only affect that instance.

`class="usa-button {{ page.button-style }} {{ include.style }}"`

And because `{{ include.style }}` follows the page-level styling, it will override the page-level settings.

This change also adds some page-level styling to the Create account template as an example.